### PR TITLE
Execute `yard doc` command in each gem directory

### DIFF
--- a/yard/Dockerfile
+++ b/yard/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /app
 
 ONBUILD COPY ruby/ /app/
 ONBUILD RUN \
-  for dir in $(find . -name '*.gemspec' | xargs dirname); do \
-    yard doc --output-dir /docs/$(basename $dir) $dir; \
+  for dir in $(find /app/ -name '*.gemspec' | xargs dirname); do \
+    cd $dir; yard doc --output-dir /docs/$(basename $dir); \
   done


### PR DESCRIPTION
This PR changes the working directory of `yard doc` command from `/app` directory to each gem directory.

YARD automatically reads its configuration files (`.yardopts` and `.documents`) and the README file in the working directory.
This change allows YARD to apply these configurations in each gem directory and include the README file in the generated documents.

## Ref

* `yardoc` documentation: https://rubydoc.info/gems/yard/YARD/CLI/Yardoc
* source code to process files in the working directory
  * https://github.com/lsegal/yard/blob/1bc142b2192164eb17c041a0e94fa99b06224160/lib/yard/cli/yardoc.rb#L297-L299
